### PR TITLE
Fix null check for values

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "",
   "license": "ISC",
   "peerDependencies": {
-    "graphql": "^15.0.0"    
+    "graphql": "^15.0.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.11",

--- a/src/values.ts
+++ b/src/values.ts
@@ -31,8 +31,12 @@ export const coerceFieldArgumentsValues = async <TSource, TContext>(
   ) => {
     const { name } = argDef;
     const argValue = values[name];
-    if (argValue == null) {
-      coercedValues[name] = argValue;
+    if (argValue === undefined) {
+      delete coercedValues[name];
+      return;
+    }
+    if (argValue === null) {
+      coercedValues[name] = null;
       return;
     }
 
@@ -66,8 +70,12 @@ const coerceInputValue = async <TContext>(
     const { name } = field;
 
     const value = values[name];
-    if (value == null) {
-      coercedValues[name] = value;
+    if (value === undefined) {
+      delete coercedValues[name];
+      return;
+    }
+    if (value === null) {
+      coercedValues[name] = null;
       return;
     }
 

--- a/src/values.ts
+++ b/src/values.ts
@@ -31,7 +31,7 @@ export const coerceFieldArgumentsValues = async <TSource, TContext>(
   ) => {
     const { name } = argDef;
     const argValue = values[name];
-    if (!argValue) return;
+    if (argValue == null) return;
 
     const coercedArgValue = await coerceArgumentValue(
       argDef,
@@ -63,7 +63,7 @@ const coerceInputValue = async <TContext>(
     const { name } = field;
 
     const value = values[name];
-    if (!value) return;
+    if (value == null) return;
 
     try {
       coercedValues[name] = await coerceInputFieldValue(

--- a/src/values.ts
+++ b/src/values.ts
@@ -31,7 +31,9 @@ export const coerceFieldArgumentsValues = async <TSource, TContext>(
   ) => {
     const { name } = argDef;
     const argValue = values[name];
-    if (argValue == null) return;
+    if (argValue == null) {
+      return argValue;
+    }
 
     const coercedArgValue = await coerceArgumentValue(
       argDef,
@@ -63,7 +65,9 @@ const coerceInputValue = async <TContext>(
     const { name } = field;
 
     const value = values[name];
-    if (value == null) return;
+    if (value == null) {
+      return value;
+    }
 
     try {
       coercedValues[name] = await coerceInputFieldValue(

--- a/src/values.ts
+++ b/src/values.ts
@@ -32,7 +32,8 @@ export const coerceFieldArgumentsValues = async <TSource, TContext>(
     const { name } = argDef;
     const argValue = values[name];
     if (argValue == null) {
-      return argValue;
+      coercedValues[name] = argValue;
+      return;
     }
 
     const coercedArgValue = await coerceArgumentValue(
@@ -66,7 +67,8 @@ const coerceInputValue = async <TContext>(
 
     const value = values[name];
     if (value == null) {
-      return value;
+      coercedValues[name] = value;
+      return;
     }
 
     try {

--- a/src/values.ts
+++ b/src/values.ts
@@ -32,7 +32,6 @@ export const coerceFieldArgumentsValues = async <TSource, TContext>(
     const { name } = argDef;
     const argValue = values[name];
     if (argValue === undefined) {
-      delete coercedValues[name];
       return;
     }
     if (argValue === null) {
@@ -71,7 +70,6 @@ const coerceInputValue = async <TContext>(
 
     const value = values[name];
     if (value === undefined) {
-      delete coercedValues[name];
       return;
     }
     if (value === null) {


### PR DESCRIPTION
Closes #3 

The prior falsiness check had the issue that no falsy values like zero, false or the empty string were validated. A nullish check gives the intended result.

The `coercedValues[name] = value;` in the null check is required to correctly forward `undefined` and `null` values. Differentiating between these is important to know whether an actuall null value has been passed for a field or if it has simply been left out.
